### PR TITLE
[Exemplo][Não Mergear]: Atualizar view count com ajax

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,8 @@ app.get('/', routes.index)
 
 app.get('/content/:id', routes.content)
 
+app.post('/content/views/increment', routes.incrementContentViewCount)
+
 app.get('/author/:idAuthor', routes.author)
 
 app.post('/course', (req, res) => {

--- a/app.js
+++ b/app.js
@@ -11,6 +11,8 @@ const app = express()
 
 const MONGO_URL = 'mongodb://localhost:27017/conhecimento-livre-dev'
 
+mongoose.Promise = Promise
+
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
 

--- a/src/routes/increment_content_view_count.js
+++ b/src/routes/increment_content_view_count.js
@@ -1,17 +1,9 @@
-module.exports = (Content) => (request, response) => {
-  Content.find({_id: request.body.id}, (error, content) => {
-    if (error) {
-      return response.status(500).json({message: error.message})
-    }
-
+module.exports = (Content) => (request, response) => Content
+  .find({_id: request.body.id})
+  .exec()
+  .then(content => {
     content.set({views: content.views + 1})
-
-    content.save((error) => {
-      if (error) {
-        return response.status(500).json({message: error.message})
-      }
-
-      return response.sendStatus(200)
-    })
+    return content.save()
   })
-}
+  .then(() => response.sendStatus(200))
+  .catch(error => response.status(500).json({message: error.message}))

--- a/src/routes/increment_content_view_count.js
+++ b/src/routes/increment_content_view_count.js
@@ -1,0 +1,17 @@
+module.exports = (Content) => (request, response) => {
+  Content.find({_id: request.body.id}, (error, content) => {
+    if (error) {
+      return response.status(500).json({message: error.message})
+    }
+
+    content.set({views: content.views + 1})
+
+    content.save((error) => {
+      if (error) {
+        return response.status(500).json({message: error.message})
+      }
+
+      return response.sendStatus(200)
+    })
+  })
+}

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -4,6 +4,7 @@ const Author = require('../../models/author')
 const Search = require('../search/search')
 const index = require('./index')
 const content = require('./content')
+const incrementContentViewCount = require('./increment_content_view_count')
 const author = require('./author')
 
 const search = new Search()
@@ -12,6 +13,7 @@ const allRoutes = {
   index: index(Course),
   content: content(Content, search),
   author: author(Author, search, Content),
+  incrementContentViewCount: incrementContentViewCount(Content),
 }
 
 module.exports = allRoutes

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -30,6 +30,7 @@
           <ul>
             {{#allContents}}
             <li>
+              <input id="content-id" type="hidden" value="{{ id }}"/>
               <a class='thumbnail' href="/content/{{ id }}">
                 <img src="http://i1.ytimg.com/vi/{{ url }}/mqdefault.jpg" alt="">
                 <div class="title-video">{{ title }}</div>
@@ -42,5 +43,13 @@
       </div>
     </div>
   </section>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.17.0/axios.js" charset="utf-8"></script>
+  <script>
+    const contentId = document.querySelector('#content-id').value
+    axios
+      .post('/content/view/increment', {id: contentId})
+      .then(() => console.log('View count atualizado'))
+      .catch(error => console.log('Erro ao atualizar view count', error.message))
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Este PR tem três commits para exemplificar o uso de Ajax para implementar o contador de visualizações de um conteúdo:

- [Implementando uma rota para incrementar as views sem utilizar Promise](https://github.com/aceleradora-TW/conhecimento-livre/pull/42/commits/19af79245e9ce84a7b1df0bfb1b55a90f946dd23)

- [Implementando a chamada Ajax com Axios](https://github.com/aceleradora-TW/conhecimento-livre/pull/42/commits/24ba5e24a00b143731158c76c0771a21640d24d6)

- [Refatorando a rota usando Promises](https://github.com/aceleradora-TW/conhecimento-livre/pull/42/commits/e99ae25897961fdf3ec75b6cadd8fcbfc6f127fc)